### PR TITLE
Add method for easier reading files.

### DIFF
--- a/src/ExcelReaders.jl
+++ b/src/ExcelReaders.jl
@@ -74,10 +74,20 @@ function readxl(file::ExcelFile, range::String)
 	readxl(file, sheetname, startrow, startcol, endrow, endcol)
 end
 
+function readxl(filename::String, sheet_index::Int=0)
+	file = openxl(filename)
+	wb = file.workbook
+	ws = wb[:sheet_by_index](sheet_index)
+    readxl_data(ws)
+end
+
 function readxl(file::ExcelFile, sheetname::String, startrow::Int, startcol::Int, endrow::Int, endcol::Int)
 	wb = file.workbook
 	ws = wb[:sheet_by_name](sheetname)
-
+    readxl_data(ws, startrow, startcol, endrow, endcol)
+end
+    
+function readxl_data(ws::PyObject, startrow::Int=0, startcol::Int=0, endrow::Int=ws[:nrows]-1, endcol::Int=ws[:ncols]-1)
 	data = DataArray(Any, endrow-startrow+1,endcol-startcol+1)
 
 	for row in startrow:endrow


### PR DESCRIPTION
It is great you took the time to wrap `xlrd`, thank you for doing this for the community. Last week I did just did a quick and dirty wrap for personal use:

```
function read_sheet(sheet, T=Any; rows=(1, sheet[:nrows]), cols=(1,sheet[:ncols]))
    out = Array(T,rows[2]-rows[1]+1, cols[2]-cols[1]+1)
    for i=range(rows[1], rows[2]-rows[1]+1), j=range(cols[1],cols[2]-cols[1]+1)
        cell = sheet[:cell](i-1,j-1)
        out[i,j] = cell[:value]
    end
    return out
end

book = xlrd.open_workbook("second_data_set.xlsx")
read_sheet(book[:sheet_by_index](1))
```

which I liked for the simplicity.

This pull implement so you can read an excel file by `readxl("Filename.xlsx")` then it just reads the first sheet or `readxl("Filename.xlsx",1)`  reads the second sheet.

I would also like to add
`readxl("Filename.xlsx","Sheet1")` this function would would return the same data as `readxl("Filename.xlsx",0)` but it interferes with you current `readxl(file::ExcelFile, range::String)`. 

My main thoughts is that it would be nicer to separate the current `range`  into two arguments one for 
`sheetname` and one for `range`. This would only be two more character than the current solution `data2 = readxl("Filename.xlsx", "Sheet2","B4:F10")`. By doing this multiple dispatch could be used to do  `data2 = readxl("Filename.xlsx", "Sheet2", 4:10, 2:7)`, `data2 = readxl("Filename.xlsx", 1,"B4:F10")` and `data2 = readxl("Filename.xlsx", 1, 4:10, 2:7)`.

Another option would be to add a custom string literal like `readxl("Filename.xlsx", xl"Sheet2!B4:F10")`. But this seems like an overkill.

Another comment is that the indexing should probably be made one indexed to follow julia instead of pythons zero indexing.
