### PR TITLE
Update REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6
 DataArrays
 DataFrames
-Dates
 PyCall 1.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6.0-rc1
+julia 0.6
 DataArrays
 DataFrames
 Dates


### PR DESCRIPTION
The [`Dates`](https://github.com/quinnj/Dates.jl) package should no longer be referenced as this has been included in Base since Julia 0.4.