### PR TITLE
Fix PyCall precompile failure on 1.11: Bump PyCall minimum version to 1.96

### DIFF
--- a/.github/workflows/jlpkgbutler-ci-master-workflow.yml
+++ b/.github/workflows/jlpkgbutler-ci-master-workflow.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.6', '1.7', '1.8', '1.9', '1.10']
+        julia-version: ['1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:

--- a/.github/workflows/jlpkgbutler-ci-pr-workflow.yml
+++ b/.github/workflows/jlpkgbutler-ci-pr-workflow.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.6', '1.7', '1.8', '1.9', '1.10']
+        julia-version: ['1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:

--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,10 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Conda = "1 - 1.8.0"
 julia = "1.6"
+Conda = "1.9"
 DataValues = "0.4.4"
-PyCall = "1.90"
+PyCall = "1.96"
 
 [targets]
 test = ["Test", "TestItemRunner"]


### PR DESCRIPTION
Also necessitates bumping compat bounds for Conda, which was previously restricted to <1.9

This is necessary because PyCall <1.96 fails to precompile on Julia 1.11 due to `Source type for reinterpret must be isbits`. See, eg, this GHA log on 1.11 x64 Ubuntu: https://github.com/angusmoore/ExcelReaders.jl/actions/runs/11586144386/job/32256244830#step:5:130

Adds 1.11 to actions strategy as well.