### PR TITLE
[WIP] CI fixes and move CI minimum to 1.10 LTS

### DIFF
--- a/.github/workflows/jlpkgbutler-ci-master-workflow.yml
+++ b/.github/workflows/jlpkgbutler-ci-master-workflow.yml
@@ -11,15 +11,20 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: ['1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        julia-version: ['1.10', '1.11', '1.12']
+        julia-arch: [x64, x86, aarch64]
+        os: [ubuntu-latest, windows-latest, macos-15]
         exclude:
-          - os: macos-13
+          - os: macos-15
             julia-arch: x86
-          - os: macos-13
-            julia-version: "1.4"
+          - os: macos-15
+            julia-arch: x64
+          - os: windows-latest
+            julia-arch: aarch64
+          - os: ubuntu-latest
+            julia-arch: aarch64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/jlpkgbutler-ci-pr-workflow.yml
+++ b/.github/workflows/jlpkgbutler-ci-pr-workflow.yml
@@ -8,15 +8,20 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: ['1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        julia-version: ['1.10', '1.11', '1.12']
+        julia-arch: [x64, x86, aarch64]
+        os: [ubuntu-latest, windows-latest, macos-15]
         exclude:
-          - os: macos-13
+          - os: macos-15
             julia-arch: x86
-          - os: macos-13
-            julia-version: "1.4"
+          - os: macos-15
+            julia-arch: x64
+          - os: windows-latest
+            julia-arch: aarch64
+          - os: ubuntu-latest
+            julia-arch: aarch64
 
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.6"
+julia = "1.10"
 Conda = "1.9"
 DataValues = "0.4.4"
 PyCall = "1.96"


### PR DESCRIPTION
Fixes up CI to get it passing again (see https://github.com/queryverse/ExcelReaders.jl/pull/113):
* Remove support for pre 1.10 (this may not be necessary, but seems reasonable)
* Add 1.11 and 1.12 to CI
* Bumps macOS runner to 15 as 13 is no longer supported
* Set fail-fast to false; this is mostly to diagnose CI failures since 32 bit linux is currently failing, and want to confirm no other errors

32-bit Linux CI will still fail until https://github.com/JuliaPy/Conda.jl/pull/268 (or alternative fix) is merged and a new release tagged. I will bump the compat bound for Conda in this PR once that release is tagged. Will leave this marked as WIP until then.